### PR TITLE
target remapping

### DIFF
--- a/igann.py
+++ b/igann.py
@@ -223,6 +223,8 @@ class IGANN:
         self.test_losses = []
         self.regressor_predictions = []
         self.boost_rate = boost_rate
+        self.target_remapped_flag = False
+        '''Is set to true during the fit method if the target (y) is remapped to -1 and 1 instead of 0 and 1.'''
 
         if task == 'classification':
             # todo: torch
@@ -311,6 +313,7 @@ class IGANN:
         if self.task == 'classification':
             # In the case of targets in {0,1}, transform them to {-1,1} for optimization purposes
             if torch.min(y) != -1:
+                self.target_remapped_flag = True
                 y = 2 * y - 1
 
         if feat_pairs != None:
@@ -704,6 +707,10 @@ class IGANN:
             else:
                 threshold = 0
             pred = np.where(pred_raw < threshold, np.ones_like(pred_raw) * -1, np.ones_like(pred_raw)).squeeze()
+
+            if self.target_remapped_flag:
+                pred = np.where(pred == -1, 0, 1)
+
             return pred
 
     def predict_raw(self, X):


### PR DESCRIPTION
This Update toggles a bool, if the target (y) is being mapped from 0 and 1 to -1 and 1 during training. During inference (.predict()) it is re-mapped to the values accordingly to the form the user passed at fitting / training time.

If the variable name created do not sound good, simply reject this PR.

Best,
Nico